### PR TITLE
Add '||:' to end of mv command

### DIFF
--- a/git-join-repos
+++ b/git-join-repos
@@ -44,7 +44,7 @@ function repo_master_to_subdir {
     git filter-branch -f --index-filter \
         "git ls-files -s | ${sed} \"s|\t\\\"*|&${repo_name}/|\" |
         GIT_INDEX_FILE=\$GIT_INDEX_FILE.new git update-index --index-info &&
-        mv \"\$GIT_INDEX_FILE.new\" \"\$GIT_INDEX_FILE\"" HEAD
+        mv \"\$GIT_INDEX_FILE.new\" \"\$GIT_INDEX_FILE\" ||:" HEAD
 
     git filter-branch -f --msg-filter "/bin/echo -n \"${repo_name}: \" && cat"
 


### PR DESCRIPTION
so that it also works with commits without any file.

See http://stackoverflow.com/questions/614229/can-i-move-the-git-directory-for-a-repo-to-its-parent-directory/614254#comment15773648_614254

I had problems running this and stumbled over the linked comment in stackoverflow. This fixed it for me. Maybe pull it to make the script more robust.
