### PR TITLE
Add --allow-unrelated-histories option to monolithic conversion merge…

### DIFF
--- a/git-join-repos
+++ b/git-join-repos
@@ -70,6 +70,6 @@ git rm -qrf --ignore-unmatch .
 for a in $name_urls; do
     split_line "$a"
 
-    git merge --ff -m "$repo_name: $self_name monolithic conversion merge" "$repo_name"
+    git merge --allow-unrelated-histories --ff -m "$repo_name: $self_name monolithic conversion merge" "$repo_name"
     git branch -D "$repo_name"
 done


### PR DESCRIPTION
… now required as per git 2.9

Ran into this same issue when trying your script: 
http://stackoverflow.com/questions/37937984/git-refusing-to-merge-unrelated-histories

Adding this option then merged successfully. 